### PR TITLE
Update to support python 3.10

### DIFF
--- a/hieratic_dynamodb/__init__.py
+++ b/hieratic_dynamodb/__init__.py
@@ -1,4 +1,4 @@
-from collections import MutableMapping
+from collections.abc import MutableMapping
 
 from six import iteritems
 from six.moves import reduce

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -23,7 +23,7 @@ def six_string(v):
     return v
 
 
-dt = Any(datetime, datetime.fromtimestamp)
+dt = Any(datetime, lambda x: datetime.fromtimestamp(float(x)))
 
 
 def pytest_addoption(parser):


### PR DESCRIPTION
Use python 3.10.8 and dynamodb-local 2.0.0 to run pytest.
```
$ AWS_ACCESS_KEY_ID='DUMMYIDEXAMPLE' AWS_SECRET_ACCESS_KEY='DUMMYEXAMPLEKEY' pytest
============================================================================= test session starts =============================================================================
platform darwin -- Python 3.10.8, pytest-7.4.0, pluggy-1.2.0
rootdir: /{workdir}/hieratic-dynamodb
collected 3 items

tests/test_flat.py .                                                                                                                                                    [ 33%]
tests/test_hierarchy.py ..                                                                                                                                              [100%]

============================================================================== 3 passed in 9.48s ==============================================================================
```